### PR TITLE
SF solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ Our answers to exercises in http://www.cis.upenn.edu/~bcpierce/sf
    the proof assistant: `coqc Basics.v`
 2. Rename it to `[your_github_name]_Basics.v` and submit it
    as a pull request to this repo.
+


### PR DESCRIPTION
Hi,

Your repo seems to be a publicly accessible version of parts of the Software Foundations text, with solutions included. I’d like to request that you take it down or at least make it non-public. Software Foundations is widely used both for self-study and for university courses. Having solutions easily available makes it much less useful for courses, which typically have graded homework assignments. The SF authors especially request that readers not post solutions to the exercises anyplace where they can be found by search engines.

Many thanks,
- Benjamin Pierce (and the other SF authors)
